### PR TITLE
Render falsy values accurately

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -49,7 +49,10 @@ type varNode struct {
 
 func (n *varNode) render(t *Template, w *writer, c ...interface{}) error {
 	w.text()
-	if v, ok := lookup(n.name, c...); ok {
+	v, _ := lookup(n.name, c...)
+	// If the value is present but 'falsy', such as a false bool, or a zero int,
+	// we still want to render that value.
+	if v != nil {
 		if n.escape {
 			v = escape(fmt.Sprintf("%v", v))
 		}

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -33,6 +33,24 @@ func TestTemplate(t *testing.T) {
 	}
 }
 
+func TestFalsyTemplate(t *testing.T) {
+	input := strings.NewReader("some text {{^foo}}{{foo}}{{/foo}} {{bar}} here")
+	template := New()
+	err := template.Parse(input)
+	if err != nil {
+		t.Error(err)
+	}
+	var output bytes.Buffer
+	err = template.Render(&output, map[string]interface{}{"foo": 0, "bar": false})
+	if err != nil {
+		t.Error(err)
+	}
+	expected := "some text 0 false here"
+	if output.String() != expected {
+		t.Errorf("expected %q got %q", expected, output.String())
+	}
+}
+
 func TestParseTree(t *testing.T) {
 	template := New()
 	template.elems = []node{


### PR DESCRIPTION
If falsy values like `false` or `0` are passed in as parameters, they should be rendered as-is, rather than mangled into empty strings.