### PR TITLE
Fixing typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ t.Render(os.Stdout, nil)
 ### String
 
 ```Go
-t := mustahce.New()
+t := mustache.New()
 err := t.ParseString("Hello, {{subject}}!")
 if err != nil {
     // handle error


### PR DESCRIPTION
```
                     _        _              
 _ __ ___  _   _ ___| |_ __ _| |__   ___ ___ 
| '_ ` _ \| | | / __| __/ _` | '_ \ / __/ _ \
| | | | | | |_| \__ \ || (_| | | | | (_|  __/
|_| |_| |_|\__,_|___/\__\__,_|_| |_|\___\___|
```