### PR TITLE
Support and ptr fields snake_case in template

### DIFF
--- a/convert_case.go
+++ b/convert_case.go
@@ -1,0 +1,16 @@
+package mustache
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	matchSnakeCase = regexp.MustCompile("(^[A-Za-z])|_([A-Za-z])")
+)
+
+func toCamelCase(camelCase string) string {
+	return matchSnakeCase.ReplaceAllStringFunc(camelCase, func(s string) string {
+		return strings.ToUpper(strings.Replace(s, "_", "", -1))
+	})
+}

--- a/convert_case_test.go
+++ b/convert_case_test.go
@@ -1,0 +1,22 @@
+package mustache
+
+import "testing"
+
+func Test_toSnakeCase(t *testing.T) {
+	tests := []struct {
+		want  string
+		input string
+	}{
+		{"", ""},
+		{"A", "a"},
+		{"AaAa", "aa_aa"},
+		{"BatteryLifeValue", "battery_life_value"},
+		{"Id0Value", "id0_value"},
+	}
+	for _, test := range tests {
+		have := toCamelCase(test.input)
+		if have != test.want {
+			t.Errorf("input=%q:\nhave: %q\nwant: %q", test.input, have, test.want)
+		}
+	}
+}

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -87,3 +87,27 @@ func TestParseTree(t *testing.T) {
 		t.Log(b.String())
 	}
 }
+
+func TestSnakeCase(t *testing.T) {
+	tmpl := New(SilentMiss(false))
+	err := tmpl.ParseString("{{test_snake_case}} {{foo}} {{Bar}}")
+	if err != nil {
+		t.Error(err)
+	}
+	type Args struct {
+		TestSnakeCase string
+		Foo           string
+		Bar           string
+	}
+	str, err := tmpl.RenderString(Args{
+		TestSnakeCase: "a",
+		Foo:           "b",
+		Bar:           "c",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if str != "a b c" {
+		t.Errorf("expected %s got %s", "a b c", str)
+	}
+}

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -111,3 +111,27 @@ func TestSnakeCase(t *testing.T) {
 		t.Errorf("expected %s got %s", "a b c", str)
 	}
 }
+
+func TestSnakeCaseAndPtr(t *testing.T) {
+	tmpl := New(SilentMiss(false))
+	err := tmpl.ParseString("{{test_snake_case}} {{foo}} {{Bar}}")
+	if err != nil {
+		t.Error(err)
+	}
+	type Args struct {
+		TestSnakeCase string
+		Foo           string
+		Bar           string
+	}
+	str, err := tmpl.RenderString(&Args{
+		TestSnakeCase: "a",
+		Foo:           "b",
+		Bar:           "c",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if str != "a b c" {
+		t.Errorf("expected %s got %s", "a b c", str)
+	}
+}


### PR DESCRIPTION
* We can use `snake_case` in a template.
* Support Pointer of struct as argument.